### PR TITLE
feature: add simplicity to initialization of the package itself 

### DIFF
--- a/_examples/size/main.go
+++ b/_examples/size/main.go
@@ -2,8 +2,9 @@ package size
 
 import (
 	"fmt"
-	"github.com/insanXYZ/sage"
 	"os"
+
+	"github.com/insanXYZ/sage"
 )
 
 func main() {
@@ -11,16 +12,13 @@ func main() {
 	//this gif image have size 167kb
 	open, _ := os.Open("giphy.gif")
 
-	//initialize sage package
-	s := sage.New()
-
 	//validate image with Validate
-	err := s.Validate(open, "minsize=100") //not error
+	err := sage.Validate(open, "minsize=100") //not error
 	if err != nil {
 		fmt.Println(err.Error())
 	}
 
-	err = s.Validate(open, "maxsize=100") //error
+	err = sage.Validate(open, "maxsize=100") //error
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/_examples/typedata/main.go
+++ b/_examples/typedata/main.go
@@ -9,18 +9,18 @@ import (
 
 func main() {
 	//open file in your pc with os.open
-	open, _ := os.Open("giphy.gif")
-
-	//initialize sage package
-	s := sage.New()
-
-	//validate image with Validate
-	err := s.Validate(open, "gif") //not error
+	open, err := os.Open("giphy.gif")
 	if err != nil {
 		fmt.Println(err.Error())
 	}
 
-	err = s.Validate(open, "png") //error
+	//validate image with Validate
+	err = sage.Validate(open, "gif") //not error
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	err = sage.Validate(open, "png") //error
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/readme.md
+++ b/readme.md
@@ -10,64 +10,70 @@ Sage is a Go library designed to simplify the task of image validation, either f
 
 #### <b>Image in your pc
 ```go
-//Sage instance
-s := sage.New()
+import (
+    "github.com/insanXYZ/sage"
+)
 
 //open file in your pc with os.open
 //note : giphy.gif have size 263kb
-open, _ := os.Open("giphy.gif")
+open, err := os.Open("giphy.gif")
+if err != nil {
+    fmt.Println(err.Error())
+}
 
 //image validation only
-err := s.Validate(open) //not error
+err := sage.Validate(open) //not error
 if err != nil {
     fmt.Println(err.Error())
 }
 
 //validate format 
-err := s.Validate(open, "gif") //not error
+err := sage.Validate(open, "gif") //not error
 if err != nil {
     fmt.Println(err.Error())
 }
 
-err = s.Validate(open, "png") //error
+err = sage.Validate(open, "png") //error
 if err != nil {
     fmt.Println(err.Error())
 }
 
 //validate size
-err := s.Validate(open, "minsize=100") //not error
+err := sage.Validate(open, "minsize=100") //not error
 if err != nil {
     fmt.Println(err.Error())
 }
 
-err = s.Validate(open, "maxsize=100") //error
+err = sage.Validate(open, "maxsize=100") //error
 if err != nil {
     fmt.Println(err.Error())
 }
 
 //validate format and size
-err = s.Validate(open, "gif","minsize=100") //not error
+err = sage.Validate(open, "gif","minsize=100") //not error
 if err != nil {
     fmt.Println(err.Error())
 }
 ```
 #### <b>Web Framework
 ```go
-//Sage instance
-s := sage.New()
+import (
+    "github.com/insanXYZ/sage"
+)
 
 //Echo (https://echo.labstack.com/)
 e := echo.New()
 
 e.POST("/image-upload", func(c echo.Context) error {
     header, _ := c.FormFile("image")
-    err := s.Validate(header)
+    err := sage.Validate(header)
     ...
 })
 ```
 ```go
-//Sage instance
-s := sage.New()
+import (
+    "github.com/insanXYZ/sage"
+)
 
 //Fiber (https://gofiber.io/)
 f := fiber.New()
@@ -81,11 +87,12 @@ fiber.Post("/image-upload", func(ctx *fiber.Ctx) error {
 
 # Tag
 
-| Tag       | Description                               |
-|:----------|:------------------------------------------|
+| Tag     | Description                             |
+|:--------|:----------------------------------------|
 | png     | image must be of type png               |
 | jpg     | image must be of type jpg               |
 | jpeg    | image must be of type jpeg              |
 | gif     | image must be of type gif               |
+| bmp     | image must be of type bmp               |
 | minsize | images must have a certain minimum size |
 | maxsize | images must have a certain maximum size |


### PR DESCRIPTION
- add simplicity to initialization of the package itself, Instead of using it like this
`import ("github.com/insanXYZ/sage")`
`sageInit := sage.New()`
`err := sageInit.Validate(image)`
`if err != nil {`
 `return err`
`}`

instead using it like this
`import ("github.com/insanXYZ/sage")`
`err := sage.Validate(image)`
`if err != nil {`
 `return err`
`}`

as simple as that
- add bmp format image 
- fix several issue on the code and on the _example
- updated readme.md file